### PR TITLE
ci: distribute binary builds across runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,38 @@ on:
   pull_request:
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      includes: ${{ steps.binary.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v5
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Run binary-all
-      run: docker buildx bake binary-all
+      -
+        name: Checkout
+        uses: actions/checkout@v6
+      -
+        name: Binary matrix
+        id: binary
+        uses: docker/bake-action/subaction/matrix@v6
+        with:
+          target: binary-all
+          fields: platforms
+
+  binary:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.includes) }}
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/bake-action@v6
+        with:
+          targets: binary
+          set: |
+            *.platform=${{ matrix.platforms }}


### PR DESCRIPTION
To reduce build time

Before:

<img width="1038" height="493" alt="image" src="https://github.com/user-attachments/assets/b7cd3df4-6492-4772-bdd6-05445bd945b4" />

After:

<img width="779" height="744" alt="image" src="https://github.com/user-attachments/assets/9c416df9-3db3-49b4-b440-897deb7a222c" />
